### PR TITLE
Refactor help system to store docs with functions

### DIFF
--- a/lispy.h
+++ b/lispy.h
@@ -39,6 +39,9 @@ struct lval {
     lval* formals;
     lval* body;
 
+    /* documentation string for builtins */
+    char* doc;
+
     /* count and pointer to a list of lval* */
     int count;
     list_t* cell;
@@ -165,7 +168,7 @@ lenv* lenv_new(void);
 void  lenv_del(lenv*);
 lval* lenv_get(lenv*, lval*);
 void  lenv_put(lenv*, lval*, lval*);
-void lenv_add_builtin(lenv*, char*, lbuiltin);
+void lenv_add_builtin(lenv*, char*, lbuiltin, char*);
 void lenv_add_builtins(lenv*);
 lenv* lenv_copy(lenv* e);
 void lenv_def(lenv*, lval*, lval*);


### PR DESCRIPTION
## Summary

- Add `doc` field to `lval` struct for storing documentation strings with functions
- Move all builtin documentation from static array to inline registration calls
- Simplify `builtin_help` to look up symbols and use the `doc` field directly
- Support both string and Q-expr syntax: `(help "print")` and `(help {print})`

## Benefits

- **Self-documenting code**: Help text lives right next to function registration
- **Single source of truth**: No separate array to keep in sync
- **Extensible**: Enables future support for user-defined function docstrings

## Example

```c
lenv_add_builtin(e, "print", builtin_print,
    "Print values to stdout.\n"
    "  Usage: (print val1 val2 ...)\n"
    "  Example: (print \"Hello\" \"World\")");
```

## Test plan

- [x] Run `./lispy tests/test_help.lspy` - all help lookups work
- [x] Run `./lispy tests/test_help_errors.lspy` - error cases handled
- [x] Test `help` command in interactive REPL - lists all builtins
- [x] Test `(help "print")` and `(help {print})` syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)